### PR TITLE
Corrige parâmetro 'pageNumber' para retorno de Empresa por CNPJ

### DIFF
--- a/lib/enotas_nfe/endpoints.rb
+++ b/lib/enotas_nfe/endpoints.rb
@@ -12,7 +12,7 @@ module EnotasNfe
     end
     
     def get_empresa_by_cnpj(cnpj)
-      get("empresas?pageNumber=1&pageSize=1&searchBy=CNPJ&searchTerm=#{cnpj}")
+      get("empresas?pageNumber=0&pageSize=1&searchBy=CNPJ&searchTerm=#{cnpj}")
     end
 
     def create_update_empresa(body)


### PR DESCRIPTION
Aparentemente a busca de Empresas com o `searchTerm` só funciona se o parâmetro `pageNumber` tiver com o valor `0`.