### PR TITLE
Adiciona atributo mei no modelo Empresa.

### DIFF
--- a/lib/enotas_nfe/model/empresa.rb
+++ b/lib/enotas_nfe/model/empresa.rb
@@ -38,6 +38,7 @@ module EnotasNfe
       attribute :emissaoNFeConsumidor, EmissaoNFeConsumidor
       attribute :configuracoesNFSeHomologacao, ConfiguracoesNFSeHomologacao
       attribute :configuracoesNFSeProducao, ConfiguracoesNFSeProducao
+      attribute :mei, Boolean
     end
   end
 end

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.36"
+  VERSION = "0.0.37"
 end


### PR DESCRIPTION
Com a mudança das emissões das notas de serviço para o padrão NFS-e Nacional, se o município aderiu ao novo modelo, as emissões de empresas MEI passarão a ser negadas na integração webservice com o município.

Para ser possível fazer a emissão, agora é necessário enviar o campo "mei" na hora de incluir/atualizar uma empresa no eNotas. Esse campo identifica se a empresa é MEI e se o município aderiu a NFS-e Nacional.

Mais detalhes no artigo: [Tudo que você precisa saber para emitir NFS-e Nacional para empresas MEI através do eNotas Gateway](https://atendimento.enotas.com.br/kb/article/408298/tudo-que-voce-precisa-saber-para-emitir-nfs-e-nacional-para-empr)