### PR TITLE
Adiciona campo metadata a EnotasNfe::Model::Empresa

### DIFF
--- a/lib/enotas_nfe/model/empresa.rb
+++ b/lib/enotas_nfe/model/empresa.rb
@@ -7,6 +7,7 @@ module EnotasNfe
       require "enotas_nfe/model/configuracoes_nfse_homologacao"
       require "enotas_nfe/model/configuracoes_nfse_producao"
       require "enotas_nfe/model/emissao_nfe_consumidor"
+      require "enotas_nfe/model/metadados"
       require 'open-uri'
 
       include Virtus.model
@@ -39,6 +40,7 @@ module EnotasNfe
       attribute :configuracoesNFSeHomologacao, ConfiguracoesNFSeHomologacao
       attribute :configuracoesNFSeProducao, ConfiguracoesNFSeProducao
       attribute :mei, Boolean
+      attribute :metadados, Metadados
     end
   end
 end

--- a/lib/enotas_nfe/model/metadados.rb
+++ b/lib/enotas_nfe/model/metadados.rb
@@ -7,6 +7,7 @@ module EnotasNfe
 
       attribute :cidadeprestacao, CidadePrestacao
       attribute :valorTotalRecebido, Float
+      attribute :regimeApuracaoTributosSN, String
     end
   end
 end

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.37"
+  VERSION = "0.0.38"
 end


### PR DESCRIPTION
Como parte da adequação do eNotas ao NFS-e Nacional, agora precisamos enviar um novo campo para a API na hora de incluir/atualizar uma empresa. O campo é o `regimeApuracaoTributosSN`, que são os regimes de tributos especificos para o portal nacional. Essa campo vai dentro dos metadados.