### PR TITLE
Adiciona PercentualTributosFederal

### DIFF
--- a/lib/enotas_nfe.rb
+++ b/lib/enotas_nfe.rb
@@ -46,6 +46,7 @@ require "enotas_nfe/model/issqn"
 require "enotas_nfe/model/pis"
 require "enotas_nfe/model/metadados"
 require "enotas_nfe/model/cidade_prestacao"
+require "enotas_nfe/model/percentual_tributos_federal"
 require "enotas_nfe/facades"
 require "enotas_nfe/client"
 

--- a/lib/enotas_nfe/model/metadados.rb
+++ b/lib/enotas_nfe/model/metadados.rb
@@ -4,10 +4,12 @@ module EnotasNfe
 
       include Virtus.model
       require "enotas_nfe/model/cidade_prestacao"
+      require "enotas_nfe/model/percentual_tributos_federal"
 
       attribute :cidadeprestacao, CidadePrestacao
       attribute :valorTotalRecebido, Float
       attribute :regimeApuracaoTributosSN, String
+      attribute :valorPercentualTributosFederal, PercentualTributosFederal
     end
   end
 end

--- a/lib/enotas_nfe/model/percentual_tributos_federal.rb
+++ b/lib/enotas_nfe/model/percentual_tributos_federal.rb
@@ -1,0 +1,13 @@
+module EnotasNfe
+  module Model
+    class PercentualTributosFederal
+
+      include Virtus.model
+
+      attribute :PercentualTotalFederal, Integer
+      attribute :PercentualTotalEstadual, Integer
+      attribute :PercentualTotalMunicipal, Integer
+    end
+  end
+end
+  

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.38"
+  VERSION = "0.0.39"
 end


### PR DESCRIPTION
Como parte da adequação do eNotas ao NFS-e Nacional, agora precisamos enviar o novo campo `valorPercentualTributosFederal` para a API na hora de incluir/atualizar uma empresa. Esse campo vai dentro dos metadados, e está representado pelo modelo `PercentualTributosFederal`