### PR TITLE
feat: add codigoNBS attribute to Servico model

### DIFF
--- a/lib/enotas_nfe/model/servico.rb
+++ b/lib/enotas_nfe/model/servico.rb
@@ -8,6 +8,7 @@ module EnotasNfe
       attribute :aliquotaIss, Float
       attribute :issRetidoFonte, Boolean
       attribute :cnae, String
+      attribute :codigoNBS, String
       attribute :codigoServicoMunicipio, String
       attribute :descricaoServicoMunicipio, String
       attribute :itemListaServicoLC116, String

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = "0.0.40"
+  VERSION = "0.0.41"
 end


### PR DESCRIPTION
Adiciona um novo campo no serviço de eNotas (https://notagateway.com.br/wp-content/uploads/2025/07/Decifrando-a-Reforma-Tributaria-Um-guia-pratico-para-Devs-v1.1.pdf)

Alguns municípios já estão exigindo o envio do código NBS, para emissão das notas fiscais, e logo vai ser obrigatório para todos. Por enquanto é possível adicionar manualmente no cadastro do eNotas, via portal deles.