### PR TITLE
Adiciona código NBS ao modelo da empresa

### DIFF
--- a/lib/enotas_nfe/model/empresa.rb
+++ b/lib/enotas_nfe/model/empresa.rb
@@ -32,6 +32,7 @@ module EnotasNfe
       attribute :codigoServicoMunicipal, String
       attribute :itemListaServicoLC116, String
       attribute :cnae, String
+      attribute :codigoNBS, String
       attribute :aedf, String
       attribute :aliquotaIss, Float
       attribute :optanteSimplesNacional, Boolean

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = '0.0.47'.freeze
+  VERSION = '0.0.48'.freeze
 end


### PR DESCRIPTION
Para a correta extração e envio do código NBS foi necessário adicionar ele ao modelo da empresa.