### PR TITLE
Adiciona campo tipoRetencaoPisCofins ao serviço da NFS-e

### DIFF
--- a/lib/enotas_nfe/model/servico.rb
+++ b/lib/enotas_nfe/model/servico.rb
@@ -21,6 +21,7 @@ module EnotasNfe
       attribute :valorIr, Float
       attribute :valorPis, Float
       attribute :valorCsll, Float
+      attribute :tipoRetencaoPisCofins, String
       attribute :ibsCbs, IbsCbs
 
     end

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = '0.0.50'.freeze
+  VERSION = '0.0.51'.freeze
 end


### PR DESCRIPTION
## O que muda

Adiciona o atributo `tipoRetencaoPisCofins` ao modelo `EnotasNfe::Model::Servico`, permitindo informar o tipo de retenção de PIS/COFINS na emissão de NFS-e via eNotas.

Valores aceitos pelo eNotas: `PisCofinsRetido` / `PisCofinsNaoRetido`.

- `lib/enotas_nfe/model/servico.rb`: novo `attribute :tipoRetencaoPisCofins, String`
- `lib/enotas_nfe/version.rb`: bump `0.0.50` → `0.0.51`

## Contexto

Necessário para a feature (atrás de feature flag) no `m1` que passa a sempre calcular PIS/COFINS na geração de notas e enviar o tipo de retenção ao eNotas com base em `pessoa.RETER_PIS_COFINS_CSLL`.

PR relacionado no `m1`: será vinculado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)