### PR TITLE
Adiciona bloco simplesNacional ao percentualAproximadoTributos

### DIFF
--- a/lib/enotas_nfe/model/percentual_aproximado_tributos.rb
+++ b/lib/enotas_nfe/model/percentual_aproximado_tributos.rb
@@ -4,8 +4,10 @@ module EnotasNfe
 
       include Virtus.model
       require "enotas_nfe/model/detalhado"
+      require "enotas_nfe/model/simples_nacional"
 
       attribute :detalhado, Detalhado
+      attribute :simplesNacional, SimplesNacional
 
     end
   end

--- a/lib/enotas_nfe/model/simples_nacional.rb
+++ b/lib/enotas_nfe/model/simples_nacional.rb
@@ -1,0 +1,11 @@
+module EnotasNfe
+  module Model
+    class SimplesNacional
+
+      include Virtus.model
+
+      attribute :aliquota, Float
+
+    end
+  end
+end

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = '0.0.51'.freeze
+  VERSION = '0.0.52'.freeze
 end


### PR DESCRIPTION
## Contexto

Suporte a monde-sistemas/issues#4307 / monde-sistemas/m1#2012.

Empresas optantes pelo Simples Nacional precisam informar a **alíquota efetiva do Simples Nacional** em campo próprio na emissão de NFS-e pelo Portal Nacional, separado do ISS. Hoje o model `PercentualAproximadoTributos` só expõe o sub-bloco `detalhado` (federal/estadual/municipal), então qualquer chave `simplesNacional` era descartada.

## Mudança

- Novo model `EnotasNfe::Model::SimplesNacional` com `attribute :aliquota, Float`.
- `PercentualAproximadoTributos` passa a expor `attribute :simplesNacional, SimplesNacional` (além do `detalhado` já existente).
- Bump de versão `0.0.51` → `0.0.52`.

Resultante:

```ruby
EnotasNfe::Model::PercentualAproximadoTributos.new(simplesNacional: { aliquota: 6.0 })
# => #<...aliquota=6.0>, detalhado=nil
```

Optantes passam a enviar `percentualAproximadoTributos.simplesNacional.aliquota`; não optantes seguem no `detalhado`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)