### PR TITLE
Adiciona bloco pisCofinsApuracaoPropria ao serviço da NFS-e

### DIFF
--- a/lib/enotas_nfe/model/pis_cofins_apuracao_propria.rb
+++ b/lib/enotas_nfe/model/pis_cofins_apuracao_propria.rb
@@ -1,0 +1,13 @@
+module EnotasNfe
+  module Model
+    class PisCofinsApuracaoPropria
+      include Virtus.model
+
+      attribute :baseCalculo, Float
+      attribute :aliquotaPis, Float
+      attribute :valorPis, Float
+      attribute :aliquotaCofins, Float
+      attribute :valorCofins, Float
+    end
+  end
+end

--- a/lib/enotas_nfe/model/servico.rb
+++ b/lib/enotas_nfe/model/servico.rb
@@ -3,6 +3,7 @@ module EnotasNfe
     class Servico
 
       require "enotas_nfe/model/ibs_cbs"
+      require "enotas_nfe/model/pis_cofins_apuracao_propria"
 
       include Virtus.model
 
@@ -23,6 +24,7 @@ module EnotasNfe
       attribute :valorCsll, Float
       attribute :tipoRetencaoPisCofins, String
       attribute :ibsCbs, IbsCbs
+      attribute :pisCofinsApuracaoPropria, PisCofinsApuracaoPropria
 
     end
   end

--- a/lib/enotas_nfe/version.rb
+++ b/lib/enotas_nfe/version.rb
@@ -1,3 +1,3 @@
 module EnotasNfe
-  VERSION = '0.0.52'.freeze
+  VERSION = '0.0.53'.freeze
 end


### PR DESCRIPTION
Parte 1 de 3 da apuração própria de PIS/COFINS — [monde-sistemas/issues#4372](https://github.com/monde-sistemas/issues/issues/4372).

Adiciona o suporte da gem ao bloco `pisCofinsApuracaoPropria`, filho de `servico` e no mesmo nível de `ibsCbs`:

```json
"servico": {
  "pisCofinsApuracaoPropria": {
    "baseCalculo": 100.00,
    "aliquotaPis": 0.65,
    "valorPis": 0.65,
    "aliquotaCofins": 3.00,
    "valorCofins": 3.00
  },
  "valorPis": 0.00,
  "valorCofins": 0.00
}
```

- novo `lib/enotas_nfe/model/pis_cofins_apuracao_propria.rb`, no molde do `ibs_cbs.rb`;
- `attribute :pisCofinsApuracaoPropria` em `servico.rb`;
- bump de versão `0.0.52` → `0.0.53`.

Apuração própria é tributo distinto da retenção — os `valorPis`/`valorCofins` que já existem em `servico` continuam sendo os valores **retidos**, conforme a [KB 575442](https://atendimento.notagateway.com.br/kb/pt-br/article/575442) anota campo a campo.

O bump do `Gemfile.lock` no m1 **não** entra aqui: vem na parte 3, apontando para a revisão desta PR já mergeada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)